### PR TITLE
[46] fix/overflow-text by changing the spacing of the first quote

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
 
         <figure class="text-center mb-0">
             <blockquote class="blockquote">
-              <p class="pb-3">
+              <p class="pb-2">
                 <i class="fas fa-quote-left fa-xs text-primary"></i>
                 <span class="lead font-italic">In the long run we shape our lives and shape ourselves. The process never ends until we die. 
                     And the choices we make are ultimately our own responsibility. </span>

--- a/styles/global.css
+++ b/styles/global.css
@@ -135,9 +135,10 @@ nav {
   .wrapper {
     width: 1200px;
     margin: 0 auto;
-    overflow: hidden;
+    overflow:hidden;
   }
 }
+
 
 @-webkit-keyframes introLoad {
   from {


### PR DESCRIPTION
#46 I fixed the overflow text of the first quote by changing pb-3 to pb-2 instead inside index.html file. Seems to look fine when shrinking. @codeByAnnie 